### PR TITLE
Force stdout and stderr streams to be unbuffered when python cmd is executed

### DIFF
--- a/neuro_flow/expr.py
+++ b/neuro_flow/expr.py
@@ -614,7 +614,7 @@ class OptBashExpr(OptStrExpr):
 class OptPythonExpr(OptStrExpr):
     @classmethod
     def convert(cls, arg: str) -> str:
-        ret = " ".join(["python3", "-c", shlex.quote(arg)])
+        ret = " ".join(["python3", "-uc", shlex.quote(arg)])
         return ret
 
 


### PR DESCRIPTION
When running a job and checking logs it may look like the job hangs.
Let's add `-u` option for python code execution to fix it.