### PR TITLE
Add support of canceled status.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/neuro_flow/batch_runner.py
+++ b/neuro_flow/batch_runner.py
@@ -22,7 +22,7 @@ from .context import BatchContext, DepCtx
 from .parser import ConfigDir, parse_batch
 from .storage import Attempt, BatchStorage, FinishedTask, StartedTask
 from .types import LocalPath
-from .utils import format_job_status
+from .utils import TERMINATED_JOB_STATUSES, format_job_status
 
 
 if sys.version_info >= (3, 9):
@@ -167,7 +167,7 @@ class BatchRunner(AsyncContextManager["BatchRunner"]):
                     if st.id in finished:
                         continue
                     status = await self._client.jobs.status(st.raw_id)
-                    if status.status in (JobStatus.FAILED, JobStatus.SUCCEEDED, JobStatus.CANCELLED):
+                    if status.status in TERMINATED_JOB_STATUSES:
                         finished[st.id] = await self._finish_task(
                             attempt,
                             len(started) + len(finished),

--- a/neuro_flow/batch_runner.py
+++ b/neuro_flow/batch_runner.py
@@ -193,10 +193,10 @@ class BatchRunner(AsyncContextManager["BatchRunner"]):
 
     def _accumulate_result(self, finished: Iterable[FinishedTask]) -> JobStatus:
         for task in finished:
-            if task.status == JobStatus.FAILED:
-                return JobStatus.FAILED
-            elif task.status == JobStatus.CANCELLED:
+            if task.status == JobStatus.CANCELLED:
                 return JobStatus.CANCELLED
+            elif task.status == JobStatus.FAILED:
+                return JobStatus.FAILED
 
         return JobStatus.SUCCEEDED
 

--- a/neuro_flow/live_runner.py
+++ b/neuro_flow/live_runner.py
@@ -250,7 +250,7 @@ class LiveRunner(AsyncContextManager["LiveRunner"]):
                     if not job.detach:
                         await self._run_subproc("neuro", "attach", descr.id)
                     return
-                # Here the status is SUCCEDED or FAILED, restart
+                # Here the status is SUCCEED, CANCELLED or FAILED, restart
             except ResourceNotFound:
                 # Job does not exist, run it
                 pass
@@ -329,7 +329,7 @@ class LiveRunner(AsyncContextManager["LiveRunner"]):
                 if descr.status in (JobStatus.PENDING, JobStatus.RUNNING):
                     await self.client.jobs.kill(descr.id)
                     descr = await self.client.jobs.status(descr.id)
-                    while descr.status not in (JobStatus.SUCCEEDED, JobStatus.FAILED):
+                    while descr.status not in (JobStatus.SUCCEEDED, JobStatus.CANCELLED, JobStatus.FAILED):
                         await asyncio.sleep(0.2)
                         descr = await self.client.jobs.status(descr.id)
                     return True
@@ -360,7 +360,7 @@ class LiveRunner(AsyncContextManager["LiveRunner"]):
             await self.client.jobs.kill(descr.id)
             try:
                 descr = await self.client.jobs.status(descr.id)
-                while descr.status not in (JobStatus.SUCCEEDED, JobStatus.FAILED):
+                while descr.status not in (JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.CANCELLED):
                     await asyncio.sleep(0.2)
                     descr = await self.client.jobs.status(descr.id)
             except ResourceNotFound:

--- a/neuro_flow/live_runner.py
+++ b/neuro_flow/live_runner.py
@@ -16,7 +16,7 @@ from typing_extensions import AsyncContextManager
 from .context import ImageCtx, LiveContext, UnknownJob, VolumeCtx
 from .parser import parse_live
 from .types import LocalPath
-from .utils import format_job_status
+from .utils import RUNNING_JOB_STATUSES, TERMINATED_JOB_STATUSES, format_job_status
 
 
 @dataclasses.dataclass(frozen=True)
@@ -326,10 +326,10 @@ class LiveRunner(AsyncContextManager["LiveRunner"]):
 
         try:
             async for descr in self._resolve_jobs(meta_ctx, suffix):
-                if descr.status in (JobStatus.PENDING, JobStatus.RUNNING):
+                if descr.status in RUNNING_JOB_STATUSES:
                     await self.client.jobs.kill(descr.id)
                     descr = await self.client.jobs.status(descr.id)
-                    while descr.status not in (JobStatus.SUCCEEDED, JobStatus.CANCELLED, JobStatus.FAILED):
+                    while descr.status not in TERMINATED_JOB_STATUSES:
                         await asyncio.sleep(0.2)
                         descr = await self.client.jobs.status(descr.id)
                     return True
@@ -360,7 +360,7 @@ class LiveRunner(AsyncContextManager["LiveRunner"]):
             await self.client.jobs.kill(descr.id)
             try:
                 descr = await self.client.jobs.status(descr.id)
-                while descr.status not in (JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.CANCELLED):
+                while descr.status not in TERMINATED_JOB_STATUSES:
                     await asyncio.sleep(0.2)
                     descr = await self.client.jobs.status(descr.id)
             except ResourceNotFound:
@@ -371,7 +371,7 @@ class LiveRunner(AsyncContextManager["LiveRunner"]):
                 return job_id
 
         async for descr in self.client.jobs.list(
-            tags=self.ctx.tags, statuses=(JobStatus.PENDING, JobStatus.RUNNING)
+            tags=self.ctx.tags, statuses=RUNNING_JOB_STATUSES
         ):
             tasks.append(loop.create_task(kill(descr)))
 

--- a/neuro_flow/utils.py
+++ b/neuro_flow/utils.py
@@ -16,4 +16,13 @@ def format_job_status(status: JobStatus) -> str:
     return click.style(status.value, fg=COLORS.get(status, "reset"))
 
 
+RUNNING_JOB_STATUSES = {JobStatus.PENDING, JobStatus.RUNNING}
+
+TERMINATED_JOB_STATUSES = {
+    JobStatus.FAILED,
+    JobStatus.SUCCEEDED,
+    JobStatus.CANCELLED,
+}
+
+
 JOB_TAG_PATTERN = r"\A[a-z](?:[-.:/]?[a-z0-9]){0,255}\Z"

--- a/neuro_flow/utils.py
+++ b/neuro_flow/utils.py
@@ -6,6 +6,7 @@ COLORS = {
     JobStatus.PENDING: "yellow",
     JobStatus.RUNNING: "blue",
     JobStatus.SUCCEEDED: "green",
+    JobStatus.CANCELLED: "green",
     JobStatus.FAILED: "red",
     JobStatus.UNKNOWN: "yellow",
 }


### PR DESCRIPTION
Recently a `canceled` status was added in Neuro API for those jobs, which were terminated with `neuro kill` command.
In this PR I would like to add support for these job statuses in `neuro-flow` since currently, it might face problems while communicating with a new API (e.g. when running `neuro-flow kill ${task_name}`)

@asvetlov, please check whether all is OK. Also, mb I should add some tests for such cases - let me know.